### PR TITLE
Add examples in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,13 @@ Usage:
   * home-assistant/core native test: `from tests.common import MockConfigEntry`
   * custom component test: `from pytest_homeassistant_custom_component.common import MockConfigEntry`
 * If your integration is inside a `custom_components` folder, a `custom_components/__init__.py` file or changes to `sys.path` may be required.
+
+Examples:
 * See [list of custom components](https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/network/dependents) as examples that use this package.
 * Also see tests for `simple_integration` in this repository.
+* Use [integration-blueprint](https://github.com/custom-components/integration_blueprint) as a template to create your custom component. A basic test suite is already implemented.
+* Use [cookiecutter-homeassistant-custom-component](https://github.com/oncleben31/cookiecutter-homeassistant-custom-component) to create a custom component similar to integration_blueprint but customized for you by using [cookiecutter](https://github.com/cookiecutter/cookiecutter).
+* The [github-custom-component-tutorial](https://github.com/boralyl/github-custom-component-tutorial) explaining in details how to create a custom componenent with a test suite using this package.
 
 This repository is set up to be nearly automatic with the goal of being fully automatic.
 To keep the releases up to date, a PR is automatically generated with new changes once a week.


### PR DESCRIPTION
Add examples: 
- integration_blupring example
-  oncleben31/cookiecutter-homeassistant-custom-component cookiecutter template
- boralyl/github-custom-component-tutorial tutorial. 

I didn't put boralyl/cookiecutter-homeassistant-component because if used alone the test suite is almost empty. I prefere promoting the tutorial who explains among many thing how to construct a good test suite. The tutorial is using boralyl cookiecutter.