### PR TITLE
Avoid recursion in replacing socket with GuardedSocket

### DIFF
--- a/pytest_homeassistant_custom_component/plugins.py
+++ b/pytest_homeassistant_custom_component/plugins.py
@@ -139,7 +139,9 @@ def disable_socket(allow_unix_socket=False):
                 return super().__new__(cls, *args, **kwargs)
             raise pytest_socket.SocketBlockedError()
 
-    socket.socket = GuardedSocket
+    socket_was_enabled = socket.socket == pytest_socket._true_socket
+    if socket_was_enabled:
+        socket.socket = GuardedSocket
 
 
 def ha_datetime_to_fakedatetime(datetime):


### PR DESCRIPTION
In a project with a lot of tests, a recursion error is eventually raised due
to the socket being replaced with a GuardedSocket at the start of each test,
but this is not undone after the test.

Add a check and if the socket has already been replaced, skip doing it again.