### PR TITLE
Fix recorder error

### DIFF
--- a/generate_phacc/const.py
+++ b/generate_phacc/const.py
@@ -15,9 +15,10 @@ files = [
     "common.py",
     "conftest.py",
     "ignore_uncaught_exceptions.py",
+    "components/recorder/common.py",
 ]
 
-# remove rrquirements for development only, i.e not related to homeassistant tests
+# remove requirements for development only, i.e not related to homeassistant tests
 requirements_remove = [
     "codecov",
     "mypy",


### PR DESCRIPTION
This change gets rid of the recorder error with HA 2022.5 that is mentioned in #115 .
It seems to generate fine and the tests of the generated `pytest-homeassistant-custom-component` run without errors.

Changes feel a bit brittle/hacky especially the docstring code. There are probably better ways to implement this, but not really a Python expert  :/ 
