### PR TITLE
Generate package during CI testing; support python 3.11

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: install dependencies generate
+    - name: Install dependencies generate
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements_generate.txt

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10"]
+        python-version: ["3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,7 +32,7 @@ jobs:
         export PYTHONPATH=$PYTHONPATH:$(pwd)
         python generate_phacc/generate_phacc.py --regen
     - name: list files
-        run: ls -a
+      run: ls -a
     - name: publish artifact
       uses: actions/upload-artifact@v2
       with:

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,9 +23,16 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: install dependencies generate
       run: |
         python -m pip install --upgrade pip
+        pip install -r requirements_generate.txt
+    - name: execute generate package
+      run: |
+        export PYTHONPATH=$PYTHONPATH:$(pwd)
+        python generate_phacc/generate_phacc.py --regen
+    - name: Install dependencies test
+      run: |
         pip install -e .
     - name: Test with pytest
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -31,6 +31,18 @@ jobs:
       run: |
         export PYTHONPATH=$PYTHONPATH:$(pwd)
         python generate_phacc/generate_phacc.py --regen
+    - name: list files
+        run: ls -a
+    - name: publish artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: generated-package
+        path: |
+          ./
+          !**/*.pyc
+          !tmp_dir/
+          !.git/
+        if-no-files-found: error
     - name: Install dependencies test
       run: |
         pip install -e .

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This repository is set up to be nearly fully automatic.
 
 * Version of home-assistant/core is given in `ha_version`, `pytest_homeassistant_custom_component.const`, and in the README above.
 * This package is generated against published releases of homeassistant and updated daily.
+* PRs should not include changes to the `pytest_homeassistant_custom_component` files.  CI testing will automatically generate the new files.
 
 ### Version Strategy
 * When changes in extraction are required, there will be a change in the minor version.

--- a/generate_phacc/const.py
+++ b/generate_phacc/const.py
@@ -12,12 +12,13 @@ diff = "git diff --exit-code"
 
 files = [
     "__init__.py",
+    "asyncio_legacy.py",  # remove when it is not longer needed
     "common.py",
     "conftest.py",
     "ignore_uncaught_exceptions.py",
     "components/recorder/common.py",
     "syrupy.py",
-    "typing.py"
+    "typing.py",
 ]
 
 # remove requirements for development only, i.e not related to homeassistant tests


### PR DESCRIPTION
This PR was originally going to be only for generating package during testing, but to test this, support for python 3.11 was added.

closes #142 