### PR TITLE
Autodetect calling filename in stack scan of common.get_fixture_path

### DIFF
--- a/generate_phacc/generate_phacc.py
+++ b/generate_phacc/generate_phacc.py
@@ -225,12 +225,20 @@ def cli(regen):
         assert len(fixture_path_lineno) == 1
         data.insert(
             fixture_path_lineno[0] + 2,
-            "    start_path = traceback.extract_stack()[-3].filename\n",
+            "    start_path = (current_file := traceback.extract_stack()[idx:=-1].filename)\n",
         )
-        data[fixture_path_lineno[0] + 7] = data[fixture_path_lineno[0] + 7].replace(
-            "__file__", "start_path"
+        data.insert(
+            fixture_path_lineno[0] + 3,
+            "    while start_path == current_file:\n",
+        )
+        data.insert(
+            fixture_path_lineno[0] + 4,
+            "        start_path = traceback.extract_stack()[idx:=idx-1].filename\n",
         )
         data[fixture_path_lineno[0] + 9] = data[fixture_path_lineno[0] + 9].replace(
+            "__file__", "start_path"
+        )
+        data[fixture_path_lineno[0] + 11] = data[fixture_path_lineno[0] + 11].replace(
             "__file__", "start_path"
         )
 

--- a/tests/fixtures/test_array.json
+++ b/tests/fixtures/test_array.json
@@ -1,0 +1,4 @@
+[
+    {"test_key1": "test_value1"},
+    {"test_key2": "test_value2"}
+]

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,9 +1,28 @@
 """Tests changes to common module."""
 import json
 
-from pytest_homeassistant_custom_component.common import load_fixture
-
+from pytest_homeassistant_custom_component.common import (
+    load_fixture, 
+    load_json_value_fixture,
+    load_json_array_fixture,
+    load_json_object_fixture
+)
 
 def test_load_fixture():
     data = json.loads(load_fixture("test_data.json"))
+    assert data == {"test_key": "test_value"}
+
+def test_load_json_value_fixture():
+    """Test load_json_value_fixture can load fixture file"""
+    data = load_json_value_fixture("test_data.json")
+    assert data == {"test_key": "test_value"}
+
+def test_load_json_array_fixture():
+    """Test load_json_array_fixture can load fixture file"""
+    data = load_json_array_fixture("test_array.json")
+    assert data == [{"test_key1": "test_value1"},{"test_key2": "test_value2"}]
+
+def test_load_json_object_fixture():
+    """Test load_json_object_fixture can load fixture file"""
+    data = load_json_object_fixture("test_data.json")
     assert data == {"test_key": "test_value"}


### PR DESCRIPTION
Excellent package! I started using it for a custom integrations and makes testing as if it was a core integration. Thanks.

I hit the issue described in #197 when using `load_json_object_fixture`.  Get_fixture_path in common.py fails finding correct path when called from `load_json_value_fixture`, `load_json_array_fixture` or `load_json_object_fixture`.  Get_fixture_path has a hardcoded -3 index onto the stack to retrieve filename. For above functions the correct depth is -4.

This pr changes `generate_phacc.py` so it will create a common.py that will scan the stack until first filename that is not equal to the first one on the stack. In this way it auto-detects the first caller outside of common.py.

The new common.py that is generated from the updated generate_phacc.py is:

```python
def get_fixture_path(filename: str, integration: str | None = None) -> pathlib.Path:
    """Get path of fixture."""
    start_path = (current_file := traceback.extract_stack()[idx:=-1].filename)
    while start_path == current_file:
        start_path = traceback.extract_stack()[idx:=idx-1].filename
    if integration is None and "/" in filename and not filename.startswith("helpers/"):
        integration, filename = filename.split("/", 1)

    if integration is None:
        return pathlib.Path(start_path).parent.joinpath("fixtures", filename)

    return pathlib.Path(start_path).parent.joinpath(
        "components", integration, "fixtures", filename
    )
```