### PR TITLE
Add support for test_diagnostics and get_diagnostics_for_config_entry

### DIFF
--- a/custom_components/simple_integration/diagnostics.py
+++ b/custom_components/simple_integration/diagnostics.py
@@ -1,0 +1,32 @@
+"""diagnostics for Simple Integration integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    CONF_PASSWORD,
+    CONF_TOKEN,
+    CONF_USERNAME,
+)
+from homeassistant.core import HomeAssistant
+
+TO_REDACT = {
+    CONF_PASSWORD,
+    CONF_USERNAME,
+    CONF_TOKEN,
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+
+    diagnostic_data: dict[str, Any] = {
+        "config_entry": async_redact_data(entry.as_dict(), TO_REDACT),
+    }
+
+    return diagnostic_data

--- a/generate_phacc/generate_phacc.py
+++ b/generate_phacc/generate_phacc.py
@@ -42,6 +42,7 @@ def cli(regen):
         os.mkdir(PACKAGE_DIR)
         os.mkdir(os.path.join(PACKAGE_DIR, "test_util"))
         os.makedirs(os.path.join(PACKAGE_DIR, "components", "recorder"))
+        os.makedirs(os.path.join(PACKAGE_DIR, "components", "diagnostics"))
         os.makedirs(os.path.join(PACKAGE_DIR, "testing_config", "custom_components", "test_constant_deprecation"))
         shutil.copy2(os.path.join(TMP_DIR, REQUIREMENTS_FILE), REQUIREMENTS_FILE)
         shutil.copy2(
@@ -67,6 +68,10 @@ def cli(regen):
         shutil.copy2(
             os.path.join(TMP_DIR, "tests", "components", "recorder", "__init__.py"),
             os.path.join(PACKAGE_DIR, "components", "recorder", "__init__.py"),
+        )
+        shutil.copy2(
+            os.path.join(TMP_DIR, "tests", "components", "diagnostics", "__init__.py"),
+            os.path.join(PACKAGE_DIR, "components", "diagnostics", "__init__.py"),
         )
         shutil.copy2(
             os.path.join(TMP_DIR, "tests", "components", "__init__.py"),
@@ -235,6 +240,21 @@ def cli(regen):
         )
 
         with open(os.path.join(PACKAGE_DIR, "common.py"), "w") as new_file:
+            new_file.writelines(data)
+
+        # modify diagnostics file
+        with open(os.path.join(PACKAGE_DIR, "components", "diagnostics", "__init__.py"), "r") as original_file:
+            data = original_file.readlines()
+
+        diagnostics_lineno = [
+            i for i, line in enumerate(data) if "from tests.typing" in line
+        ]
+        assert len(diagnostics_lineno) == 1
+        data[diagnostics_lineno[0]] = data[diagnostics_lineno[0]].replace(
+            "tests.typing","pytest_homeassistant_custom_component.typing"
+        )
+
+        with open(os.path.join(PACKAGE_DIR, "components", "diagnostics", "__init__.py"), "w") as new_file:
             new_file.writelines(data)
 
 

--- a/tests/__snapshots__/test_diagnostics.ambr
+++ b/tests/__snapshots__/test_diagnostics.ambr
@@ -1,0 +1,25 @@
+# serializer version: 1
+# name: test_entry_diagnostics
+  dict({
+    'config_entry': dict({
+      'data': dict({
+        'name': 'simple config',
+      }),
+      'disabled_by': None,
+      'discovery_keys': dict({
+      }),
+      'domain': 'simple_integration',
+      'minor_version': 1,
+      'options': dict({
+      }),
+      'pref_disable_new_entities': False,
+      'pref_disable_polling': False,
+      'source': 'user',
+      'subentries': list([
+      ]),
+      'title': 'Mock Title',
+      'unique_id': None,
+      'version': 1,
+    }),
+  })
+# ---

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,46 @@
+"""Test the Simple Integration diagnostics."""
+
+from syrupy.assertion import SnapshotAssertion
+
+from homeassistant.core import HomeAssistant
+
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.components.diagnostics import get_diagnostics_for_config_entry
+from pytest_homeassistant_custom_component.typing import ClientSessionGenerator
+
+from custom_components.simple_integration.const import DOMAIN
+
+# Fields to exclude from snapshot as they change each run
+TO_EXCLUDE = {
+    "id",
+    "device_id",
+    "via_device_id",
+    "last_updated",
+    "last_changed",
+    "last_reported",
+    "created_at",
+    "modified_at",
+    "entry_id",
+}
+
+
+def limit_diagnostic_attrs(prop, path) -> bool:
+    """Mark attributes to exclude from diagnostic snapshot."""
+    return prop in TO_EXCLUDE
+
+
+async def test_entry_diagnostics(
+    hass: HomeAssistant,
+    hass_client: ClientSessionGenerator,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test config entry diagnostics."""
+
+    entry = MockConfigEntry(domain=DOMAIN, data={"name": "simple config",})
+    entry.add_to_hass(hass)
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert await get_diagnostics_for_config_entry(
+        hass, hass_client, entry
+    ) == snapshot(exclude=limit_diagnostic_attrs)


### PR DESCRIPTION
Testing diagnostics for a custom integration typically uses `get_diagnostics_for_config_entry`:

```python
from tests.components.diagnostics import get_diagnostics_for_config_entry
```

This is currently missing from the tool. This PR implements this so it can be used as

```
from pytest_homeassistant_custom_component.components.diagnostics import get_diagnostics_for_config_entry
```

- `generate_phacc.py`is updated to create `components/diagnostics` and copy \_\_init\_\_.py from `tests/components/diagnostics`.
- replaces the `tests.components` by `pytest_homeassistant_custom_component.components` in the copied \_\_init\_\_.py
- A skeleton diagnostics.py, test_diagnostics.py and a diagnostics test snapshot are added as well. 