### PR TITLE
Set asyncio_default_fixture_loop_scope to fix  depractionwarning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,4 @@
 [tool:pytest]
 testpaths = tests
 asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function


### PR DESCRIPTION
Pytest is showing depercation warnings for unset asyncio_default_fixture_loop_scope 


_PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset._

_The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"_

This PR adds 

```
asyncio_default_fixture_loop_scope = function
```

to setup,cfg to fix the issue. Function was the default mode.