### PR TITLE
Switch to async_forward_entry_setups and async_unload_platforms

### DIFF
--- a/custom_components/simple_integration/__init__.py
+++ b/custom_components/simple_integration/__init__.py
@@ -1,12 +1,8 @@
 """The Simple Integration integration."""
-import asyncio
-
-import voluptuous as vol
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 
-from .const import DOMAIN
 
 PLATFORMS = ["sensor"]
 
@@ -19,25 +15,14 @@ async def async_setup(hass: HomeAssistant, config: dict):
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Set up Simple Integration from a config entry."""
 
-    for component in PLATFORMS:
-        hass.async_create_task(
-            hass.config_entries.async_forward_entry_setup(entry, component)
-        )
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry):
     """Unload a config entry."""
-    unload_ok = all(
-        await asyncio.gather(
-            *[
-                hass.config_entries.async_forward_entry_unload(entry, component)
-                for component in PLATFORMS
-            ]
-        )
-    )
-    if unload_ok:
-        hass.data[DOMAIN].pop(entry.entry_id)
+
+    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     return unload_ok


### PR DESCRIPTION
When running pytest test, verbose log shows

_WARNING:homeassistant.helpers.frame:Detected code that calls async_forward_entry_setup for integration simple_integration with title: Mock Title and entry_id: 01JPWW68M72FS0V11C7Q5VN9ZP, during setup without awaiting async_forward_entry_setup, which can cause the setup lock to be released before the setup is done. This will stop working in Home Assistant 2025.1, please report this issue_

and

```
Traceback (most recent call last):
  File "/home/arie/dev/pytest-homeassistant-custom-component/.venv/lib/python3.13/site-packages/homeassistant/config_entries.py", line 967, in async_unload
    result = await component.async_unload_entry(hass, self)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/arie/dev/pytest-homeassistant-custom-component/custom_components/simple_integration/__init__.py", line 41, in async_unload_entry
    hass.data[DOMAIN].pop(entry.entry_id)
    ~~~~~~~~~^^^^^^^^
KeyError: 'simple_integration'
```

\_\_init\_\_.py is based on older ha structures. async_forward_entry_setup is [depracated](https://developers.home-assistant.io/blog/2024/06/12/async_forward_entry_setups/)

This PR implements `async_forward_entry_setups` and its counterpart `async_unload_platforms` to solve the second error.
