### PR TITLE
Make pytest-socket optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,21 @@ tests/
         return snapshot.use_extension(HomeAssistantSnapshotExtension)
 ```
 
+## Installation
+
+### Basic Installation
+```bash
+pip install pytest-homeassistant-custom-component
+```
+
+### With Socket Testing Support
+If you need network socket testing capabilities (using pytest-socket), install with the socket extra:
+```bash
+pip install pytest-homeassistant-custom-component[socket]
+```
+
+The pytest-socket plugin helps prevent tests from making real network calls by blocking socket access. This is optional and only needed if you want to ensure your tests don't accidentally make network connections.
+
 ## Examples:
 * See [list of custom components](https://github.com/MatthewFlamm/pytest-homeassistant-custom-component/network/dependents) as examples that use this package.
 * Also see tests for `simple_integration` in this repository.

--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,15 @@ from setuptools import setup, find_packages
 requirements = [
     "sqlalchemy",
 ]
+optional_requirements = []
 with open("requirements_test.txt","r") as f:
     for line in f:
-        if "txt" not in line and "#" not in line:
-            requirements.append(line)
+        line = line.strip()
+        if "txt" not in line and "#" not in line and line:
+            if line.startswith("pytest-socket"):
+                optional_requirements.append(line)
+            else:
+                requirements.append(line)
 
 with open("version", "r") as f:
     __version__ = f.read()
@@ -21,6 +26,9 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.13",
     install_requires=requirements,
+    extras_require={
+        "socket": optional_requirements,
+    },
     license="MIT license",
     url="https://github.com/MatthewFlamm/pytest-homeassistant-custom-component",
     author_email="matthewflamm0@gmail.com",


### PR DESCRIPTION
That way, this library can be used for integration/end-to-end tests.

Closes #217 