### PR TITLE
Fix ModuleNotFoundError for tests.common in components/__init__.py

### DIFF
--- a/generate_phacc/const.py
+++ b/generate_phacc/const.py
@@ -15,6 +15,7 @@ files = [
     "common.py",
     "conftest.py",
     "ignore_uncaught_exceptions.py",
+    "components/__init__.py",
     "components/recorder/common.py",
     "patch_time.py",
     "syrupy.py",

--- a/generate_phacc/generate_phacc.py
+++ b/generate_phacc/generate_phacc.py
@@ -74,10 +74,6 @@ def cli(regen):
             os.path.join(PACKAGE_DIR, "components", "diagnostics", "__init__.py"),
         )
         shutil.copy2(
-            os.path.join(TMP_DIR, "tests", "components", "__init__.py"),
-            os.path.join(PACKAGE_DIR, "components", "__init__.py"),
-        )
-        shutil.copy2(
             os.path.join(TMP_DIR, "tests", "testing_config", "__init__.py"),
             os.path.join(PACKAGE_DIR, "testing_config", "__init__.py"),
         )


### PR DESCRIPTION
For transparency:
- This was solved using Claude Code 
- A lokal test build was successful, and i was able to update my custom component

Root Cause

  On November 25, 2025, Home Assistant added new functionality to tests/components/__init__.py including:
  from tests.common import MockConfigEntry, mock_device_registry

  This file was copied directly without import transformation because it wasn't in the files list.

  Fix Applied

  Two changes made:

  1. generate_phacc/const.py: Added "components/__init__.py" to the files list so it gets the import transformation
  2. generate_phacc/generate_phacc.py: Removed the redundant direct copy of components/__init__.py (it's now copied via the files loop)

  The transformation will convert:
  - from tests.common import ... → from ..common import ...

  This matches the correct relative import path from components/__init__.py to common.py.