### PR TITLE
Remove prek

### DIFF
--- a/generate_phacc/const.py
+++ b/generate_phacc/const.py
@@ -31,6 +31,7 @@ requirements_remove = [
     "mypy",
     "mypy-dev",
     "pre-commit",
+    "prek",
     "pylint",
     "astroid",
 ]


### PR DESCRIPTION
The Home Assistant project started using `prek` as an alternative to `pre-commit`.
https://pypi.org/project/prek/