### PR TITLE
Remove pylint-per-file-ignores

### DIFF
--- a/generate_phacc/const.py
+++ b/generate_phacc/const.py
@@ -34,6 +34,7 @@ requirements_remove = [
     "pre-commit",
     "prek",
     "pylint",
+    "pylint-per-file-ignores",
     "pytest-sugar",
     "astroid",
 ]


### PR DESCRIPTION
The latests `pylint-per-file-ignores` releases added `pylint` as dependency.
https://github.com/SAP/pylint-per-file-ignores/blob/v3.2.1/pyproject.toml#L27