### PR TITLE
Publish pre-releases when tracking a homeassistant pre-release (#250)

### DIFF
--- a/.github/workflows/automatic_generation.yml
+++ b/.github/workflows/automatic_generation.yml
@@ -96,8 +96,23 @@ jobs:
           dry_run: true
           bump: patch
           github_token: ${{ secrets.REPO_SCOPED_TOKEN }}
-      - run: echo "${{ steps.next_version.outputs.version }}" > version
-      - run: echo "${{ steps.next_version.outputs.version }}"
+      - name: Determine prerelease
+        id: prerelease
+        # When the bundled homeassistant version is a pre-release (e.g. 2026.5.0b0),
+        # append a PEP 440 pre-release segment (b0) to the normally-bumped version so
+        # phacc is published as a pre-release.
+        run: |
+          HA_VERSION="${{ needs.generate_package.outputs.new_ha_version }}"
+          BASE_VERSION="${{ steps.next_version.outputs.version }}"
+          if [[ "$HA_VERSION" == *b* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "version=${BASE_VERSION}b0" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+      - run: echo "${{ steps.prerelease.outputs.version }}" > version
+      - run: echo "${{ steps.prerelease.outputs.version }}"
       - id: git_commit
         run: |
           git config user.name 'Matthew Flamm'
@@ -117,12 +132,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
         with:
           tag_name: ${{ steps.next_version.outputs.version }}
-          release_name: Release ${{ steps.next_version.outputs.version }}
+          release_name: Release ${{ steps.prerelease.outputs.version }}
           body: |
             Automatic release
             homeassistant version: ${{ needs.generate_package.outputs.new_ha_version }}
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/.github/workflows/make_release.yml
+++ b/.github/workflows/make_release.yml
@@ -21,8 +21,23 @@ jobs:
           dry_run: true
           bump: ${{ github.event.inputs.type }}
           github_token: ${{ secrets.REPO_SCOPED_TOKEN }}
-      - run: echo "${{ steps.next_version.outputs.version }}" > version
-      - run: echo "${{ steps.next_version.outputs.version }}"
+      - name: Determine prerelease
+        id: prerelease
+        # When the bundled homeassistant version is a pre-release (e.g. 2026.5.0b0),
+        # append a PEP 440 pre-release segment (b0) to the normally-bumped version so
+        # phacc is published as a pre-release.
+        run: |
+          HA_VERSION="${{ steps.current-ha-version.outputs.current-ha-version }}"
+          BASE_VERSION="${{ steps.next_version.outputs.version }}"
+          if [[ "$HA_VERSION" == *b* ]]; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+            echo "version=${BASE_VERSION}b0" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+            echo "version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          fi
+      - run: echo "${{ steps.prerelease.outputs.version }}" > version
+      - run: echo "${{ steps.prerelease.outputs.version }}"
       - id: git_commit
         run: |
           git config user.name 'Matthew Flamm'
@@ -42,12 +57,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.REPO_SCOPED_TOKEN }}
         with:
           tag_name: ${{ steps.next_version.outputs.version }}
-          release_name: Release ${{ steps.next_version.outputs.version }}
+          release_name: Release ${{ steps.prerelease.outputs.version }}
           body: |
             Automatic release
             homeassistant version: ${{ steps.current-ha-version.outputs.current-ha-version }}
           draft: false
-          prerelease: false
+          prerelease: ${{ steps.prerelease.outputs.is_prerelease }}
       - name: Set up Python
         uses: actions/setup-python@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This changelog only includes changes directly related to the structure of this p
 Changes to minor version indicate a change structurally in this pacakge.  Changes in patch indicate changes solely from homeassistant/core. The latter does not imply no breaking changes are introduced.
 
 ## 0.13.0
+* Releases tracking a homeassistant pre-release (e.g. `2026.5.0b0`) are now
+  published as pre-releases (e.g. `0.13.337b0`) (#250).
 * bump minimum Python version to Python 3.10
 
 ## 0.8.0


### PR DESCRIPTION
When generate_phacc picks up a homeassistant pre-release tag (e.g. 2026.5.0b0) it pins homeassistant==2026.5.0b0 in requirements. Until now phacc was still published as a stable PyPI release, so dependabot/uv would suggest it and then fail to resolve the unenabled homeassistant pre-release.

The release workflows now detect a 'b' in the bundled homeassistant version and, when present, append a 'b0' PEP 440 pre-release segment to the normally bumped version (e.g. 0.13.337b0) and mark the GitHub release as a pre-release. dependabot/uv/pip ignore pre-releases by default. The git tag is kept as plain semver so the semver-release-action bump chain keeps working.

resolves #250 