### PR TITLE
Remove ast-serialize

### DIFF
--- a/generate_phacc/const.py
+++ b/generate_phacc/const.py
@@ -27,6 +27,7 @@ files = [
 
 # remove requirements for development only, i.e not related to homeassistant tests
 requirements_remove = [
+    "ast-serialize",
     "codecov",
     "librt",
     "mypy",


### PR DESCRIPTION
`ast-serialize` is an internal dependency of mypy, similar to `librt` which is already excluded.
https://pypi.org/project/ast-serialize/