### PR TITLE
Fix lingering timer issue when using Bluetooth

### DIFF
--- a/src/pytest_homeassistant_custom_component/plugins.py
+++ b/src/pytest_homeassistant_custom_component/plugins.py
@@ -2037,7 +2037,7 @@ def mock_bleak_scanner_start() -> Generator[MagicMock]:
             bluetooth_scanner.OriginalBleakScanner,  # pylint: disable=c-extension-no-member
             "start",
         ) as mock_bleak_scanner_start,
-        patch.object(bluetooth_scanner, "HaScanner"),
+        patch("homeassistant.components.bluetooth.HaScanner"),
         patch.object(
             bluetooth_manager, "MGMTBluetoothCtl", return_value=mock_mgmt_bluetooth_ctl
         ),


### PR DESCRIPTION
Since pytest 9 and HA 2026.06 I run into annoying test issues with my custom integration.
```python
@pytest.mark.usefixtures("enable_bluetooth")
async def test_device_not_supported(
    bt_discovery_notsupported: BluetoothServiceInfoBleak, hass: HomeAssistant
) -> None:
    """Test discovery via bluetooth with a invalid device."""

    result: ConfigFlowResult = await hass.config_entries.flow.async_init(
        DOMAIN,
        context={"source": SOURCE_BLUETOOTH},
        data=bt_discovery_notsupported,
    )

    assert result.get("type") == FlowResultType.ABORT
    assert result.get("reason") == "not_supported"
```
results in 
```bash
ERROR    habluetooth.scanner:__init__.py:415 hci0 (00:00:00:00:00:01): Failed to force stop scanner
Traceback (most recent call last):
  File "src/habluetooth/scanner_bleak.py", line 964, in habluetooth.scanner_bleak.HaScanner._async_force_stop_discovery
  File "src/habluetooth/scanner_bleak.py", line 965, in habluetooth.scanner_bleak.HaScanner._async_force_stop_discovery
  File "/homeassistant/BMS_BLE-HA/.venv/lib/python3.14/site-packages/bleak_retry_connector/bluez.py", line 315, in stop_discovery
    await manager._bus.send(
          ^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'send'
```
causing
```
E                       Failed: Lingering timer after test <TimerHandle when=195.94811598 BaseHaScanner._async_expire_devices_schedule_next() created at /homeassistant/BMS_BLE-HA/.venv/lib/python3.14/site-packages/homeassistant/components/bluetooth/__init__.py:404>
```
After days I figured out that the patch does not catch all instances of HaScanner and thus causes some scanners to start resulting in the lingering timer.
This modification fixes the issue.