### PR TITLE
Add dev pip extra

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include requirements_test.txt
+include requirements_dev.txt
+include version

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Package to automatically extract testing plugins from Home Assistant for custom 
 The goal is to provide the same functionality as the tests in home-assistant/core.
 pytest-homeassistant-custom-component is updated daily according to the latest homeassistant release including beta.
 
+## Installation
+
+```sh
+pip install pytest-homeassistant-custom-component
+```
+
+To run linting, type checking, or pre-commit checks for your custom component
+with tool versions matching Home Assistant, install the `dev` extra:
+
+```sh
+pip install "pytest-homeassistant-custom-component[dev]"
+```
+
 ## Usage:
 * All pytest fixtures can be used as normal, like `hass`
 * For helpers:

--- a/generate_phacc/const.py
+++ b/generate_phacc/const.py
@@ -5,6 +5,7 @@ REQUIREMENTS_FILE = "requirements_test.txt"
 CONST_FILE = "const.py"
 
 REQUIREMENTS_FILE_DEV = "requirements_dev.txt"
+REQUIREMENTS_FILE_PRE_COMMIT = "requirements_test_pre_commit.txt"
 
 path = "."
 clone = "git clone https://github.com/home-assistant/core.git tmp_dir"

--- a/generate_phacc/generate_phacc.py
+++ b/generate_phacc/generate_phacc.py
@@ -14,6 +14,7 @@ from const import (
     REQUIREMENTS_FILE,
     CONST_FILE,
     REQUIREMENTS_FILE_DEV,
+    REQUIREMENTS_FILE_PRE_COMMIT,
     LICENSE_FILE_HA,
     LICENSE_FILE_NEW,
     files,
@@ -189,6 +190,14 @@ def cli(regen):
         add_dependency("paho-mqtt", data, new_data)
         add_dependency("numpy", data, new_data)
 
+        # Use the pre-commit pins from the same Home Assistant checkout as the tests.
+        with open(os.path.join(TMP_DIR, REQUIREMENTS_FILE_PRE_COMMIT), "r") as f:
+            for line in f:
+                requirement = line.strip()
+                if requirement and not requirement.startswith(("#", "-")):
+                    removed_data.append(f"{requirement}\n")
+
+        removed_data = list(dict.fromkeys(removed_data))
         removed_data.insert(0, added_text)
 
         with open(REQUIREMENTS_FILE, "w") as new_file:

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -23,3 +23,7 @@ types-pytz==2026.3.1.20260727
 types-PyYAML==6.0.12.20260724
 types-requests==2.33.0.20260712
 types-xmltodict==1.0.1.20260518
+codespell==2.4.3
+ruff==0.16.3
+yamllint==1.38.0
+zizmor==1.29.0

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,13 @@ with open("requirements_test.txt","r") as f:
         if "txt" not in line and "#" not in line:
             requirements.append(line)
 
+with open("requirements_dev.txt", "r") as f:
+    dev_requirements = [
+        line.strip()
+        for line in f
+        if line.strip() and not line.lstrip().startswith(("#", "-"))
+    ]
+
 with open("version", "r") as f:
     __version__ = f.read()
 
@@ -21,6 +28,7 @@ setup(
     package_dir={"": "src"},
     python_requires=">=3.14",
     install_requires=requirements,
+    extras_require={"dev": dev_requirements},
     license="MIT license",
     url="https://github.com/MatthewFlamm/pytest-homeassistant-custom-component",
     author_email="matthewflamm0@gmail.com",


### PR DESCRIPTION
Adds a `dev` extra for custom component developers who want linting, type checking, and pre-commit tools with versions matching Home Assistant:

```sh
pip install "pytest-homeassistant-custom-component[dev]"
```

The extra combines the existing development requirements with Home Assistant’s pre-commit tool requirements from the same release.

Closes #245.